### PR TITLE
Add date to docker tag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ build-container: compile
 
 upload-current:
 	make build-container
-	docker push behance/ecr-login:`git rev-parse HEAD`
-	docker tag behance/ecr-login:`git rev-parse HEAD` behance/ecr-login:latest
+	docker push behance/ecr-login:`git rev-parse HEAD`_`date +%Y%m%d`
+	docker tag behance/ecr-login:`git rev-parse HEAD`_`date +%Y%m%d` behance/ecr-login:latest
 	docker push behance/ecr-login:latest
 
 build: install-deps compile

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build-container: compile
 	@echo "Building ecr-login container ..."
 	@grep -q docker /proc/1/cgroup ; \
 	if [ $$? -ne 0 ]; then \
-		docker build --tag behance/ecr-login:`git rev-parse HEAD` .; \
+		docker build --tag behance/ecr-login:`git rev-parse HEAD`_`date +%Y%m%d` .; \
 	else \
 		echo "You're in a docker container. Leave to run docker" ;\
 	fi


### PR DESCRIPTION
To ensure the docker image contains an recent set of trusted
certificates a new image must be created periodically.  Since this
project is unlikely to be updated very often, it is likely that
consecutive docker images will have the same git SHA.  Prior to this
commit, such images would also have the same docker tag.  This change
adds the date to the docker tag.

An alternative to this would be to have the jenkins job perform a git
commit with the updated certs file, however IMHO this solution seems equally
valid.
